### PR TITLE
feat(spectate): follow cam + one-command GM seat on a running test

### DIFF
--- a/conf/mod_dungeon_clear.conf.dist
+++ b/conf/mod_dungeon_clear.conf.dist
@@ -1240,13 +1240,26 @@ DungeonClear.AdvanceWindowYards = 0.0
 
 #
 #    DungeonClear.SpectateEnable
-#        Master gate for the spectator free-camera (`.dc spectate` or the addon's
-#        Spectate button). The camera detaches the player from their character —
-#        the bots keep playing the body while the player free-flies the instance.
-#        Some servers consider this a cheat, so it can be disabled here: with 0,
-#        attempting to spectate is refused with "Spectator mode is disabled on
-#        this server." (an active spectate can still be ended). This is a
-#        server-only setting; players cannot override it from the addon.
+#        Master gate for the spectator camera, in both of its modes:
+#            `.dc spectate`              — free-flying camera (addon: left-click
+#                                          Spectate). Detaches the player from
+#                                          their character; the bots keep
+#                                          playing the body while the player
+#                                          flies the instance.
+#            `.dc spectate follow [name]`— follow cam (addon: right-click
+#                                          Spectate). The view rides a bot and
+#                                          tracks it as the server moves it,
+#                                          handing off to another tank if that
+#                                          one dies or logs out.
+#            `.dc test watch [selector]` — GM only: teleport into a running
+#                                          `.dc test` instance (GM mode on so
+#                                          the run can't see you) and start the
+#                                          follow cam on arrival. `off` ends it.
+#        Neither mode requires a group. Some servers consider detaching the
+#        camera a cheat, so it can be disabled here: with 0, attempting to
+#        spectate is refused with "Spectator mode is disabled on this server."
+#        (an active spectate can still be ended). This is a server-only setting;
+#        players cannot override it from the addon.
 #            0 = disabled
 #            1 = enabled
 #        Default: 1 (enabled)
@@ -1260,7 +1273,8 @@ DungeonClear.SpectateEnable = 1
 #        or the addon's Spectate button) — how fast the detached camera flies,
 #        as a multiple of normal run speed. The camera is a possessed invisible
 #        dummy, so this affects only the camera, never the character (which
-#        keeps running under bot AI at its own speed).
+#        keeps running under bot AI at its own speed). Follow cam ignores this:
+#        it rides a bot rather than flying, so its speed is the bot's.
 #
 #        Default: 2.5
 #

--- a/src/DungeonClearAddonHook.cpp
+++ b/src/DungeonClearAddonHook.cpp
@@ -168,17 +168,27 @@ public:
             PLAYERHOOK_ON_LOGOUT
         }) {}
 
-    // True for the addon's client->server control messages, which ride in as a
-    // party/raid addon chat line of the form "DC\tCMD\t<sub>[\t<param>]". Shared
-    // by the parse hook (OnPlayerBeforeSendChatMessage, which acts on them) and
-    // the relay-block hook (OnPlayerCanUseChat, which stops the core forwarding
+    // True for the addon's client->server control messages, which ride in as an
+    // addon chat line of the form "DC\tCMD\t<sub>[\t<param>]". Shared by the
+    // parse hook (OnPlayerBeforeSendChatMessage, which acts on them) and the
+    // relay-block hook (OnPlayerCanUseChat, which stops the core forwarding
     // them to the rest of the group).
+    //
+    // WHISPER is the solo transport. The addon's normal channel is PARTY/RAID,
+    // which simply does not exist for a player with no group — so a GM watching
+    // a test run from outside the bot party could not press any button at all,
+    // spectate included, even though the spectator camera itself has never had
+    // a group requirement. A whisper to oneself is the standard addon-message
+    // channel for that case. The server dispatch self-authorizes either way
+    // (bot commands still need a tank bot in the sender's group and say so),
+    // so accepting the extra channel grants no new authority.
     static bool IsDcAddonCommand(uint32 type, uint32 lang, std::string const& msg)
     {
         if (lang != LANG_ADDON)
             return false;
         if (type != CHAT_MSG_PARTY && type != CHAT_MSG_PARTY_LEADER &&
-            type != CHAT_MSG_RAID && type != CHAT_MSG_RAID_LEADER)
+            type != CHAT_MSG_RAID && type != CHAT_MSG_RAID_LEADER &&
+            type != CHAT_MSG_WHISPER)
             return false;
         // "DC\t" (3) + "CMD\t" (4) = 7-byte prefix.
         return msg.compare(0, 7, "DC\tCMD\t") == 0;
@@ -243,12 +253,16 @@ public:
             return;
         }
 
-        // Spectator free-camera: acts on the sending player directly (session
-        // plumbing, not a tank-bot action) — never dispatched.
+        // Spectator camera: acts on the sending player directly (session
+        // plumbing, not a tank-bot action) — never dispatched. Bare = the
+        // free-flying camera; "follow" rides the run's tank instead.
         if (subCmd == "spectate")
         {
             std::string whyNot;
-            if (!DcSpectator::Toggle(player, &whyNot))
+            bool const ok = (param == "follow")
+                ? DcSpectator::ToggleFollow(player, nullptr, &whyNot)
+                : DcSpectator::Toggle(player, &whyNot);
+            if (!ok)
                 SendAddonError(player, whyNot);
             return;
         }

--- a/src/DungeonClearCommand.cpp
+++ b/src/DungeonClearCommand.cpp
@@ -16,9 +16,14 @@
 #include "Chat.h"
 #include "ChatCommand.h"
 #include "Group.h"
+#include "InstanceSaveMgr.h"
+#include "Map.h"
+#include "ObjectAccessor.h"
 #include "Player.h"
 #include "StringFormat.h"
 
+#include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <sstream>
@@ -121,11 +126,16 @@ namespace
         return true;
     }
 
-    // Spectator free-camera toggle. Acts on the ISSUER directly (session
-    // plumbing, not bot behavior) — it must NOT go through DispatchToTankBots
-    // or the action pipeline: the issuer may not even be the tank, and the
-    // possession belongs to their session alone. See Util/DcSpectator.h.
-    bool HandleSpectate(ChatHandler* handler)
+    // Spectator camera toggle. Acts on the ISSUER directly (session plumbing,
+    // not bot behavior) — it must NOT go through DispatchToTankBots or the
+    // action pipeline: the issuer may not even be the tank, and the camera
+    // belongs to their session alone. See Util/DcSpectator.h.
+    //
+    // Bare `.dc spectate` is the free-flying camera; `.dc spectate follow
+    // [name]` rides a bot instead. Neither needs a group — that gate lives only
+    // in the addon's party-channel transport, which is why a GM watching from
+    // outside the party has to type the command.
+    bool HandleSpectate(ChatHandler* handler, Optional<std::string> param)
     {
         Player* issuer = handler->GetSession() ? handler->GetSession()->GetPlayer() : nullptr;
         if (!issuer)
@@ -134,7 +144,43 @@ namespace
             return true;
         }
 
+        std::string arg = param ? *param : "";
+        std::string sub;
+        std::string name;
+        {
+            std::istringstream in(arg);
+            in >> sub >> name;
+        }
+        std::transform(sub.begin(), sub.end(), sub.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
         std::string whyNot;
+        if (sub == "follow")
+        {
+            // An explicit name picks the seat; without one the camera resolves
+            // the run's driving tank on this map.
+            Player* target = nullptr;
+            if (!name.empty())
+            {
+                target = ObjectAccessor::FindPlayerByName(name, false);
+                if (!target)
+                {
+                    handler->PSendSysMessage("No player named '{}' is online.", name);
+                    return true;
+                }
+            }
+
+            if (!DcSpectator::ToggleFollow(issuer, target, &whyNot))
+                handler->SendSysMessage(whyNot);
+            return true;
+        }
+
+        if (!sub.empty() && sub != "free")
+        {
+            handler->SendSysMessage("Usage: .dc spectate [follow [name]]");
+            return true;
+        }
+
         if (!DcSpectator::Toggle(issuer, &whyNot))
             handler->SendSysMessage(whyNot);
         return true;
@@ -163,6 +209,8 @@ public:
             { "status", HandleTestStatus, SEC_GAMEMASTER, Console::Yes },
             { "stop",   HandleTestStop,   SEC_GAMEMASTER, Console::Yes },
             { "list",   HandleTestList,   SEC_GAMEMASTER, Console::Yes },
+            // Console::No — a camera needs a session to attach to.
+            { "watch",  HandleTestWatch,  SEC_GAMEMASTER, Console::No },
             { "plan",   dcTestPlanTable },
         };
         static ChatCommandTable dcTable =
@@ -275,6 +323,115 @@ public:
         std::string msg;
         DcTestRunManager::Instance().Stop(std::string(selector), &msg);
         handler->SendSysMessage(msg);
+        return true;
+    }
+
+    // `.dc test watch [selector]` — put the GM's camera on a running test.
+    //
+    // This is the one-command answer to "let me watch a run": the GM is NOT in
+    // the bot party (by design — see DcTestRunManager), so watching used to
+    // mean hand-running `.appear <botname>` then `.dc spectate`, and the addon
+    // button refuses outright because its transport is the party channel.
+    //
+    // Sequence: hide the GM (mobs must not aggro the watcher and corrupt the
+    // run), bind + teleport into the run's instance, and arm the follow camera
+    // to start on arrival — the teleport is asynchronous, and the teleport
+    // teardown hook deliberately stops any live camera on the way out, so the
+    // camera cannot be started here. `.dc test watch off` ends it and puts the
+    // GM's own visibility back.
+    static bool HandleTestWatch(ChatHandler* handler, Tail selectorArg)
+    {
+        Player* gm = handler->GetSession() ? handler->GetSession()->GetPlayer() : nullptr;
+        if (!gm)
+        {
+            handler->SendSysMessage("This command must be used in-game.");
+            return true;
+        }
+
+        std::string selector(selectorArg);
+        if (selector == "off" || selector == "stop")
+        {
+            // Unconditional: Stop also disarms a request that is still waiting
+            // out a loading screen, which IsActive can't see. It announces on
+            // its own when a camera was actually running.
+            bool const wasActive = DcSpectator::IsActive(gm);
+            DcSpectator::Stop(gm);
+            if (!wasActive)
+                handler->SendSysMessage("No spectator camera running (any pending watch request is cancelled).");
+            return true;
+        }
+
+        ObjectGuid tankGuid;
+        std::string msg;
+        if (!DcTestRunManager::Instance().WatchTarget(selector, &tankGuid, &msg))
+        {
+            handler->SendSysMessage(msg);
+            return true;
+        }
+
+        Player* tank = ObjectAccessor::FindConnectedPlayer(tankGuid);
+        if (!tank || !tank->IsInWorld())
+        {
+            handler->SendSysMessage("That run's tank isn't in the world yet — try again in a moment.");
+            return true;
+        }
+
+        handler->PSendSysMessage("Watching {}", msg);
+
+        // Already standing in the run's instance: nothing to teleport, just
+        // take the seat.
+        if (gm->IsInWorld() && gm->GetMap() == tank->GetMap())
+        {
+            std::string whyNot;
+            if (!DcSpectator::StartFollow(gm, tank, &whyNot))
+                handler->SendSysMessage(whyNot);
+            return true;
+        }
+
+        // Hide the watcher before they land. A visible, targetable GM in the
+        // instance pulls aggro and invalidates the very run being observed.
+        // DcSpectator::Stop restores this exactly when we were the ones to
+        // change it.
+        bool const gmModeApplied = !gm->IsGameMaster();
+        if (gmModeApplied)
+        {
+            gm->SetGameMaster(true);
+            handler->SendSysMessage("GM mode enabled so the run doesn't see you (restored when you stop).");
+        }
+
+        // Instance bind + difficulty, mirroring the core's `.appear` path
+        // (cs_misc.cpp): without the bind the teleport drops the GM into a
+        // fresh instance of the map instead of the run's.
+        Map* tankMap = tank->GetMap();
+        InstancePlayerBind* bind = sInstanceSaveMgr->PlayerGetBoundInstance(
+            gm->GetGUID(), tank->GetMapId(), tank->GetDifficulty(tankMap->IsRaid()));
+        if (!bind)
+        {
+            if (InstanceSave* save = sInstanceSaveMgr->GetInstanceSave(tank->GetInstanceId()))
+                sInstanceSaveMgr->PlayerBindToInstance(gm->GetGUID(), save, !save->CanReset(), gm);
+        }
+
+        if (tankMap->IsRaid())
+            gm->SetRaidDifficulty(tank->GetRaidDifficulty());
+        else
+            gm->SetDungeonDifficulty(tank->GetDungeonDifficulty());
+
+        gm->SaveRecallPosition();   // `.recall` gets the GM back out
+
+        // Arm the camera AFTER the teleport call, never before: TeleportTo
+        // fires PLAYERHOOK_ON_BEFORE_TELEPORT synchronously, and that hook
+        // calls DcSpectator::Stop — which disarms pending requests. Arming
+        // first would have the teleport immediately cancel its own camera.
+        if (!gm->TeleportTo(tank->GetMapId(), tank->GetPositionX(), tank->GetPositionY(),
+                            tank->GetPositionZ(), tank->GetOrientation()))
+        {
+            if (gmModeApplied)
+                gm->SetGameMaster(false);
+            handler->SendSysMessage("Teleport into the run's instance was refused.");
+            return true;
+        }
+
+        DcSpectator::RequestFollowOnArrival(gm, tankGuid, gmModeApplied);
         return true;
     }
 

--- a/src/DungeonClearModule.cpp
+++ b/src/DungeonClearModule.cpp
@@ -158,6 +158,11 @@ public:
 // Closing half of the mover window — see DungeonClearSpectatorMoverBeginScript
 // for the full story. NOT registered in AddSC_dungeon_clear_module(): it must
 // be instantiated on the first world tick so it sorts after playerbots' hook.
+//
+// This is also where the spectator camera's own slow tick runs (pending-arrival
+// start + follow-target re-resolution). It must sit AFTER the window closes,
+// never between Begin and End: the tick can Stop a live camera, and tearing a
+// possession down inside the bracket would leave the mover swap half-applied.
 class DungeonClearSpectatorMoverEndScript : public PlayerScript
 {
 public:
@@ -166,9 +171,10 @@ public:
             PLAYERHOOK_ON_AFTER_UPDATE
         }) {}
 
-    void OnPlayerAfterUpdate(Player* player, uint32 /*p_time*/) override
+    void OnPlayerAfterUpdate(Player* player, uint32 p_time) override
     {
         DcSpectator::EndBotAiMoverWindow(player);
+        DcSpectator::Tick(player, p_time);
     }
 };
 
@@ -325,9 +331,17 @@ public:
 
     // Despawn the dummy before the session goes away; never let the
     // TempSummon outlive its possessor.
+    //
+    // The second call is the crash guard for the OTHER side of a follow
+    // camera: this hook fires for every logging-out player, bots included
+    // (PlayerbotHolder::LogoutPlayerBot -> WorldSession::LogoutPlayer, whose
+    // very first act is this hook), and a watched bot that is deleted without
+    // clearing its viewers leaves their m_seer dangling. See
+    // DcSpectator::NotifyWatchedLoggingOut.
     void OnPlayerBeforeLogout(Player* player) override
     {
         DcSpectator::Stop(player);
+        DcSpectator::NotifyWatchedLoggingOut(player);
     }
 };
 

--- a/src/TestRun/DcTestRunManager.cpp
+++ b/src/TestRun/DcTestRunManager.cpp
@@ -117,6 +117,53 @@ bool DcTestRunManager::Start(Player* gm, std::string const& dungeonToken,
     return true;
 }
 
+bool DcTestRunManager::WatchTarget(std::string const& selector, ObjectGuid* tankOut,
+                                   std::string* msg) const
+{
+    std::vector<DcTestRunSelect::RunRef> refs;
+    refs.reserve(_runs.size());
+    for (auto const& job : _runs)
+        refs.push_back({job->RunId(), job->DungeonToken()});
+
+    DcTestRunSelect::Result const res = DcTestRunSelect::Resolve(selector, refs);
+    switch (res.kind)
+    {
+        case DcTestRunSelect::Kind::NoRuns:
+            if (msg)
+                *msg = "no test run active";
+            return false;
+        case DcTestRunSelect::Kind::Ambiguous:
+            if (msg)
+                *msg = "multiple test runs active — specify a runId or dungeon token:\n" +
+                       ListActiveRuns();
+            return false;
+        case DcTestRunSelect::Kind::NotFound:
+            if (msg)
+                *msg = "no run matches '" + selector + "' — active runs:\n" + ListActiveRuns();
+            return false;
+        case DcTestRunSelect::Kind::All:
+        case DcTestRunSelect::Kind::Matched:
+            break;
+    }
+
+    // A camera can only sit in one instance. "all", or a token matching several
+    // runs, is a question with no single answer — say so instead of guessing.
+    if (res.indices.size() != 1)
+    {
+        if (msg)
+            *msg = "'" + selector + "' matches " + std::to_string(res.indices.size()) +
+                   " runs — watch one at a time:\n" + ListActiveRuns();
+        return false;
+    }
+
+    DcTestRunJob const* job = _runs[res.indices.front()].get();
+    if (tankOut)
+        *tankOut = job->TankGuid();
+    if (msg)
+        *msg = job->RunId() + " (" + job->DungeonToken() + ")";
+    return true;
+}
+
 bool DcTestRunManager::Stop(std::string const& selector, std::string* msg)
 {
     std::vector<DcTestRunSelect::RunRef> refs;

--- a/src/TestRun/DcTestRunManager.h
+++ b/src/TestRun/DcTestRunManager.h
@@ -75,6 +75,13 @@ public:
     // no-runs / ambiguous / not-found.
     bool Stop(std::string const& selector, std::string* msg);
 
+    // Resolve the selector to ONE run's leader tank, for `.dc test watch` — the
+    // GM camera needs a single seat, so "all" and a bare selector with several
+    // runs live are both refused with the run list in *msg (same selector
+    // grammar and messages as Stop, minus the fan-out).
+    bool WatchTarget(std::string const& selector, ObjectGuid* tankOut,
+                     std::string* msg) const;
+
     std::string StatusText() const;
     bool IsActive() const { return !_runs.empty(); }
 

--- a/src/Util/DcSpectator.cpp
+++ b/src/Util/DcSpectator.cpp
@@ -1,16 +1,25 @@
 /*
  * mod-dungeon-clear — DcSpectator.cpp
  *
- * See DcSpectator.h for the design. The load-bearing detail: the possess
- * branch of Unit::SetCharmedBy sets UNIT_FLAG_DISABLE_MOVE on the CHARMER
- * (the player body). Nearly every MotionMaster entry point refuses a
- * UNIT_FLAG_DISABLE_MOVE owner — including the two DungeonClear uses,
- * MovePoint (MotionMaster.cpp:488) and MoveSplinePath (MotionMaster.cpp:506) —
- * so without clearing that flag the bot body freezes solid the moment the
- * camera detaches. We clear it immediately after a successful possess; it is
- * a one-time set (nothing re-asserts it during possession), and
- * RemoveCharmedBy clears it again on teardown, so the early clear is harmless
- * on exit.
+ * See DcSpectator.h for the design and the Free-vs-Follow split.
+ *
+ * Free mode's load-bearing detail: the possess branch of Unit::SetCharmedBy
+ * sets UNIT_FLAG_DISABLE_MOVE on the CHARMER (the player body). Nearly every
+ * MotionMaster entry point refuses a UNIT_FLAG_DISABLE_MOVE owner — including
+ * the two DungeonClear uses, MovePoint (MotionMaster.cpp:488) and
+ * MoveSplinePath (MotionMaster.cpp:506) — so without clearing that flag the bot
+ * body freezes solid the moment the camera detaches. We clear it immediately
+ * after a successful possess; it is a one-time set (nothing re-asserts it
+ * during possession), and RemoveCharmedBy clears it again on teardown, so the
+ * early clear is harmless on exit.
+ *
+ * Follow mode's load-bearing detail: Player::SetViewpoint stores the seer in
+ * PLAYER_FARSIGHT via AddGuidValue, which REFUSES to overwrite a non-empty
+ * field. Possession also parks the dummy there (SetClientControl ->
+ * SetViewpoint). So the two modes can never be applied on top of one another —
+ * every entry point tears the other down first, and ClearViewpoint below
+ * force-clears the field when the watched unit has vanished, because
+ * SetViewpoint(obj, false) needs a live object to hand back.
  */
 
 #include "Util/DcSpectator.h"
@@ -18,42 +27,83 @@
 #include <atomic>
 #include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #include "Chat.h"
 #include "Creature.h"
+#include "Group.h"
 #include "Map.h"
 #include "ObjectAccessor.h"
 #include "Player.h"
+#include "PlayerbotAI.h"
+#include "Playerbots.h"
 #include "TemporarySummon.h"
 
 #include "Ai/Dungeon/DungeonClear/Settings/DcSettings.h"
+#include "Ai/Dungeon/DungeonClear/Util/DcLeaderSignal.h"
 
 namespace
 {
-    // player guid -> possessed camera-dummy guid. Never store the dummy as a
-    // raw Creature* — resolve via ObjectAccessor at each use so a despawn race
-    // can't dangle. Guarded by g_mutex: teardown hooks fire on map threads and
-    // the AI mover window reads this from every map thread (see header).
-    std::mutex g_mutex;
-    std::unordered_map<ObjectGuid, ObjectGuid> g_spectators;
+    enum class Mode : uint8
+    {
+        Free,       // possessed dummy, client-steered
+        Follow      // farsight on a bot, server-steered
+    };
 
-    // Lock-free fast path for the per-tick mover window: zero on the
-    // overwhelmingly common no-spectator server, so the window costs one
-    // relaxed atomic load per bot tick.
+    struct SpectatorState
+    {
+        Mode mode = Mode::Free;
+        ObjectGuid dummy;               // Free: the possessed camera TempSummon
+        ObjectGuid watched;             // Follow: the unit the camera rides
+        bool gmModeApplied = false;     // we turned GM mode on; undo it on Stop
+        uint32 retargetAccumMs = 0;
+    };
+
+    // A Follow camera armed before its viewer finished zoning in. Started by
+    // Tick once the viewer lands on the tank's map (see RequestFollowOnArrival).
+    struct PendingFollow
+    {
+        ObjectGuid tank;
+        bool gmModeApplied = false;
+        uint32 ageMs = 0;
+    };
+
+    // Give up on an unfulfilled arrival request rather than latching a stale
+    // intent forever — a teleport that never lands (declined, disconnected,
+    // bounced back) must not ambush the GM with a camera minutes later.
+    constexpr uint32 PENDING_FOLLOW_TIMEOUT_MS = 60 * 1000;
+
+    // How often a live Follow camera re-resolves its target. Slow on purpose:
+    // it only has to notice a leader re-election or a death, and every swap
+    // costs a visibility rebuild around the new seer.
+    constexpr uint32 RETARGET_INTERVAL_MS = 2000;
+
+    // player guid -> camera state. Never store the dummy or the watched unit as
+    // a raw pointer — resolve via ObjectAccessor at each use so a despawn race
+    // can't dangle. Guarded by g_mutex: teardown hooks fire on map threads and
+    // both Tick and the AI mover window read this from every map thread.
+    std::mutex g_mutex;
+    std::unordered_map<ObjectGuid, SpectatorState> g_spectators;
+    std::unordered_map<ObjectGuid, PendingFollow> g_pending;
+
+    // Lock-free fast path for the per-tick entry points: zero on the
+    // overwhelmingly common no-spectator server, so Tick and the mover window
+    // cost one relaxed atomic load per player tick. Counts pending requests
+    // too — an armed request still needs Tick to run for its viewer.
     std::atomic<uint32> g_activeCount{0};
 
-    // Snapshot the dummy guid for a player, or false when not spectating.
-    bool LookupDummy(Player* player, ObjectGuid& dummyGuid)
+    // Snapshot a player's camera state, or false when not spectating.
+    bool LookupState(Player* player, SpectatorState& out)
     {
         std::lock_guard<std::mutex> lock(g_mutex);
         auto it = g_spectators.find(player->GetGUID());
         if (it == g_spectators.end())
             return false;
-        dummyGuid = it->second;
+        out = it->second;
         return true;
     }
 
-    void Announce(Player* player, char const* msg)
+    void Announce(Player* player, std::string const& msg)
     {
         if (player->GetSession())
             ChatHandler(player->GetSession()).SendSysMessage(msg);
@@ -64,6 +114,55 @@ namespace
         if (whyNot)
             *whyNot = reason;
         return false;
+    }
+
+    // Shared entry validation for both modes.
+    bool CommonStartChecks(Player* player, std::string* whyNot)
+    {
+        // Admin gate: some servers treat detaching the player from their body as
+        // a cheat. Server-only conf flag, so a player can't override it. Only the
+        // entry path is gated — Stop() is always allowed so an in-progress
+        // spectate can still be ended if the flag is flipped off mid-session.
+        if (!DcSettings::GetBool(player, "SpectateEnable"))
+            return Refuse(whyNot, "Spectator mode is disabled on this server.");
+        if (!player->IsAlive())
+            return Refuse(whyNot, "You are dead.");
+        if (player->GetVehicle())
+            return Refuse(whyNot, "Cannot spectate while on a vehicle.");
+        if (player->IsInFlight())
+            return Refuse(whyNot, "Cannot spectate while on a flight path.");
+        if (player->GetCharmGUID())
+            return Refuse(whyNot, "Cannot spectate while controlling another unit.");
+        if (player->GetViewpoint())
+            return Refuse(whyNot, "Cannot spectate while viewing through something else.");
+        return true;
+    }
+
+    // Drop the player's farsight, live object or not. SetViewpoint(obj, false)
+    // is the correct path (it also unregisters us from the target's vision
+    // list), but it needs the object — when the watched bot has logged out or
+    // changed map we still have to clear PLAYER_FARSIGHT ourselves, or the
+    // field stays latched and the next AddGuidValue refuses.
+    void ClearViewpoint(Player* player, ObjectGuid watched)
+    {
+        if (watched.IsEmpty())
+            return;
+
+        if (Player* target = ObjectAccessor::FindConnectedPlayer(watched))
+            player->SetViewpoint(target, false);
+        else
+        {
+            player->SetSeer(player);
+            player->SetGuidValue(PLAYER_FARSIGHT, ObjectGuid::Empty);
+        }
+    }
+
+    // Is this bot still worth watching from `viewer`'s seat?
+    bool IsWatchable(Player* viewer, Player* target)
+    {
+        return target && target != viewer && target->IsInWorld() &&
+               target->GetMap() == viewer->GetMap() &&
+               GET_PLAYERBOT_AI(target) && target->IsAlive();
     }
 }
 
@@ -77,32 +176,81 @@ namespace DcSpectator
         return g_spectators.count(player->GetGUID()) != 0;
     }
 
+    bool IsFollowing(Player* player)
+    {
+        if (!player)
+            return false;
+        std::lock_guard<std::mutex> lock(g_mutex);
+        auto it = g_spectators.find(player->GetGUID());
+        return it != g_spectators.end() && it->second.mode == Mode::Follow;
+    }
+
+    ObjectGuid WatchedGuid(Player* player)
+    {
+        if (!player)
+            return ObjectGuid::Empty;
+        std::lock_guard<std::mutex> lock(g_mutex);
+        auto it = g_spectators.find(player->GetGUID());
+        if (it == g_spectators.end() || it->second.mode != Mode::Follow)
+            return ObjectGuid::Empty;
+        return it->second.watched;
+    }
+
+    Player* ResolveWatchTarget(Player* viewer, Player* exclude)
+    {
+        if (!viewer)
+            return nullptr;
+
+        // In a group with the run: the elected leader tank is the run's driver,
+        // and therefore the most informative seat in the house.
+        if (viewer->GetGroup())
+            if (Player* leader = DcLeaderSignal::FindLeaderTank(viewer))
+                if (leader != exclude && IsWatchable(viewer, leader))
+                    return leader;
+
+        // Outside the party — the GM-watcher case, and the reason this function
+        // exists at all. Scan the map for the bot driving a dungeon-clear run,
+        // falling back to any alive tank bot. An instance holds one party, so
+        // this walks a handful of players, at most once every couple of seconds.
+        Map* map = viewer->GetMap();
+        if (!map)
+            return nullptr;
+
+        Player* fallback = nullptr;
+        Map::PlayerList const& players = map->GetPlayers();
+        for (Map::PlayerList::const_iterator it = players.begin(); it != players.end(); ++it)
+        {
+            Player* candidate = it->GetSource();
+            if (candidate == exclude || !IsWatchable(viewer, candidate))
+                continue;
+
+            // The run's driver: exactly the bot whose decisions you want to see.
+            if (DcLeaderSignal::IsDungeonClearLeader(candidate))
+                return candidate;
+
+            if (!fallback && PlayerbotAI::IsTank(candidate))
+                fallback = candidate;
+        }
+
+        return fallback;
+    }
+
     bool Start(Player* player, std::string* whyNot)
     {
         if (!player)
             return Refuse(whyNot, "No player.");
         if (IsActive(player))
             return Refuse(whyNot, "Already spectating.");
-        // Admin gate: some servers treat detaching the player from their body as
-        // a cheat. Server-only conf flag, so a player can't override it. Only the
-        // entry path is gated — Stop() is always allowed so an in-progress
-        // spectate can still be ended if the flag is flipped off mid-session.
-        if (!DcSettings::GetBool(player, "SpectateEnable"))
-            return Refuse(whyNot, "Spectator mode is disabled on this server.");
-        // Spectator mode is a dungeon-clear feature: the camera follows bots
+        if (!CommonStartChecks(player, whyNot))
+            return false;
+        // Free-fly is a dungeon-clear feature: the camera flies around bots
         // running an instance. Outside a dungeon there is nothing to spectate,
         // and possessing a WORLD_TRIGGER in the open world has caused issues.
+        // (Follow mode carries no such restriction — farsight is the same
+        // mechanism Mind Vision uses, and works anywhere.)
         Map* map = player->GetMap();
         if (!map || !map->IsDungeon())
-            return Refuse(whyNot, "Spectator mode is only available inside a dungeon.");
-        if (!player->IsAlive())
-            return Refuse(whyNot, "You are dead.");
-        if (player->GetVehicle())
-            return Refuse(whyNot, "Cannot spectate while on a vehicle.");
-        if (player->IsInFlight())
-            return Refuse(whyNot, "Cannot spectate while on a flight path.");
-        if (player->GetCharmGUID())
-            return Refuse(whyNot, "Cannot spectate while controlling another unit.");
+            return Refuse(whyNot, "Free-fly spectator mode is only available inside a dungeon.");
 
         // Core-defined invisible utility template — no creature_template SQL
         // row needed, runtime hardening below covers the rest.
@@ -138,10 +286,78 @@ namespace DcSpectator
 
         {
             std::lock_guard<std::mutex> lock(g_mutex);
-            g_spectators[player->GetGUID()] = dummy->GetGUID();
+            SpectatorState& state = g_spectators[player->GetGUID()];
+            state.mode = Mode::Free;
+            state.dummy = dummy->GetGUID();
         }
         g_activeCount.fetch_add(1, std::memory_order_release);
         Announce(player, "Spectator camera on — your character stays under bot control. Toggle again to return.");
+        return true;
+    }
+
+    bool StartFollow(Player* player, Player* target, std::string* whyNot)
+    {
+        if (!player)
+            return Refuse(whyNot, "No player.");
+
+        // Read the arrival request's GM-mode flag BEFORE any Stop below: Stop
+        // disarms a pending request, and losing this flag would strand the GM
+        // invisible after the camera ends.
+        bool gmModeApplied = false;
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            auto pending = g_pending.find(player->GetGUID());
+            if (pending != g_pending.end())
+                gmModeApplied = pending->second.gmModeApplied;
+        }
+
+        // Switching modes is a legitimate one-step operation: tear the free
+        // camera down first rather than making every caller sequence it (and
+        // rather than letting SetViewpoint silently refuse the already-latched
+        // PLAYER_FARSIGHT field).
+        if (IsActive(player))
+            Stop(player);
+
+        if (!CommonStartChecks(player, whyNot))
+            return false;
+
+        if (!target)
+            target = ResolveWatchTarget(player);
+        if (!target)
+            return Refuse(whyNot, "No bot here to follow.");
+        if (!IsWatchable(player, target))
+            return Refuse(whyNot, "That target can't be followed from here.");
+
+        // Farsight: the camera rides the target and the client renders its
+        // ordinary server-driven movement. No client control is granted, which
+        // is exactly what makes this smooth where possession is not.
+        player->SetViewpoint(target, true);
+
+        // The body keeps its own movement input while farsighted (Mind Vision
+        // behaves the same way), so root it — otherwise a blind WASD tap walks
+        // the watcher through the instance while they stare at the party.
+        // SetControlled, not Unit::SetRooted: the latter is protected, and
+        // reaching for it would mean a core edit for a convenience root.
+        player->SetControlled(true, UNIT_STATE_ROOT);
+
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            SpectatorState& state = g_spectators[player->GetGUID()];
+            state.mode = Mode::Follow;
+            state.watched = target->GetGUID();
+            state.retargetAccumMs = 0;
+            // Carry over a GM-mode flip made by the watch entry point (snapshot
+            // above), so Stop puts the GM back the way it found them.
+            state.gmModeApplied = gmModeApplied;
+
+            // This request is now fulfilled — consume it.
+            if (g_pending.erase(player->GetGUID()))
+                g_activeCount.fetch_sub(1, std::memory_order_release);
+        }
+        g_activeCount.fetch_add(1, std::memory_order_release);
+
+        Announce(player, "Following " + target->GetName() +
+                 " — your view rides the bot. `.dc spectate follow` again to stop.");
         return true;
     }
 
@@ -150,23 +366,35 @@ namespace DcSpectator
         if (!player)
             return;
 
-        ObjectGuid dummyGuid;
+        SpectatorState state;
         {
             std::lock_guard<std::mutex> lock(g_mutex);
+
+            // Drop any unfulfilled arrival request too: a Stop means the human
+            // changed their mind, and an armed camera must not fire later.
+            if (g_pending.erase(player->GetGUID()))
+                g_activeCount.fetch_sub(1, std::memory_order_release);
+
             auto it = g_spectators.find(player->GetGUID());
             if (it == g_spectators.end())
                 return;
-            dummyGuid = it->second;
+            state = it->second;
             g_spectators.erase(it);
         }
         g_activeCount.fetch_sub(1, std::memory_order_release);
 
-        if (Creature* dummy = ObjectAccessor::GetCreature(*player, dummyGuid))
+        if (state.mode == Mode::Follow)
+        {
+            ClearViewpoint(player, state.watched);
+            player->SetControlled(false, UNIT_STATE_ROOT);
+            player->UpdateVisibilityForPlayer();
+        }
+        else if (Creature* dummy = ObjectAccessor::GetCreature(*player, state.dummy))
         {
             dummy->RemoveCharmedBy(player);
             dummy->DespawnOrUnsummon();
         }
-        else if (player->GetCharmGUID() == dummyGuid)
+        else if (player->GetCharmGUID() == state.dummy)
         {
             // Stale half-state: the dummy is gone but the charm bookkeeping
             // still points at it. StopCastingCharm walks the generic uncharm
@@ -174,11 +402,62 @@ namespace DcSpectator
             player->StopCastingCharm();
         }
 
+        // Put a GM we un-hid back the way we found them, so a watcher can't
+        // wander off still invisible and untargetable without noticing.
+        if (state.gmModeApplied && player->IsGameMaster())
+            player->SetGameMaster(false);
+
         // Deliberately no motion-master surgery on the body here: DC's own AI
         // re-issues movement on its next tick. Per the stale-MoveFollow lesson,
         // only clean up what WE installed — the possession and the dummy.
 
         Announce(player, "Spectator camera off.");
+    }
+
+    void NotifyWatchedLoggingOut(Player* watched)
+    {
+        if (!watched || g_activeCount.load(std::memory_order_acquire) == 0)
+            return;
+
+        ObjectGuid const watchedGuid = watched->GetGUID();
+
+        // Collect first, act second: Stop/SetViewpoint must not run under the
+        // lock (they call back into core visibility code), and the viewer set
+        // is at most a handful of entries.
+        std::vector<ObjectGuid> viewers;
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            for (auto const& entry : g_spectators)
+                if (entry.second.mode == Mode::Follow && entry.second.watched == watchedGuid)
+                    viewers.push_back(entry.first);
+        }
+
+        for (ObjectGuid const& viewerGuid : viewers)
+        {
+            Player* viewer = ObjectAccessor::FindConnectedPlayer(viewerGuid);
+            if (!viewer)
+                continue;
+
+            // Hand the camera to another live bot when there is one, so a
+            // watcher doesn't get kicked out of the run just because one member
+            // logged out. Otherwise end the camera cleanly.
+            Player* next = ResolveWatchTarget(viewer, watched);
+            if (next)
+            {
+                viewer->SetViewpoint(watched, false);
+                viewer->SetViewpoint(next, true);
+                viewer->UpdateVisibilityForPlayer();
+
+                std::lock_guard<std::mutex> lock(g_mutex);
+                auto it = g_spectators.find(viewerGuid);
+                if (it != g_spectators.end())
+                    it->second.watched = next->GetGUID();
+            }
+            else
+            {
+                Stop(viewer);
+            }
+        }
     }
 
     bool Toggle(Player* player, std::string* whyNot)
@@ -191,19 +470,132 @@ namespace DcSpectator
         return Start(player, whyNot);
     }
 
+    bool ToggleFollow(Player* player, Player* target, std::string* whyNot)
+    {
+        if (IsFollowing(player))
+        {
+            Stop(player);
+            return true;
+        }
+        return StartFollow(player, target, whyNot);
+    }
+
+    void RequestFollowOnArrival(Player* viewer, ObjectGuid tankGuid, bool gmModeApplied)
+    {
+        if (!viewer)
+            return;
+
+        std::lock_guard<std::mutex> lock(g_mutex);
+        auto const res = g_pending.insert({viewer->GetGUID(), PendingFollow()});
+        if (res.second)
+            g_activeCount.fetch_add(1, std::memory_order_release);
+
+        PendingFollow& pending = res.first->second;
+        pending.tank = tankGuid;
+        // A repeat request must not forget that the FIRST one hid the GM.
+        pending.gmModeApplied = pending.gmModeApplied || gmModeApplied;
+        pending.ageMs = 0;
+    }
+
+    void Tick(Player* player, uint32 diff)
+    {
+        if (!player || g_activeCount.load(std::memory_order_acquire) == 0)
+            return;
+
+        // --- pending arrival ------------------------------------------------
+        ObjectGuid pendingTank;
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            auto it = g_pending.find(player->GetGUID());
+            if (it != g_pending.end())
+            {
+                it->second.ageMs += diff;
+                if (it->second.ageMs >= PENDING_FOLLOW_TIMEOUT_MS)
+                {
+                    g_pending.erase(it);
+                    g_activeCount.fetch_sub(1, std::memory_order_release);
+                }
+                else
+                    pendingTank = it->second.tank;
+            }
+        }
+
+        if (!pendingTank.IsEmpty())
+        {
+            // Wait for the loading screen to end and the viewer to actually be
+            // standing on the tank's map before turning the camera on.
+            Player* tank = ObjectAccessor::FindConnectedPlayer(pendingTank);
+            if (tank && !player->IsBeingTeleported() && player->IsInWorld() &&
+                tank->IsInWorld() && tank->GetMap() == player->GetMap())
+            {
+                std::string whyNot;
+                if (!StartFollow(player, tank, &whyNot))
+                {
+                    // Refused on arrival (dead, disabled, …): report once and
+                    // disarm rather than retrying every tick forever.
+                    Announce(player, whyNot);
+                    std::lock_guard<std::mutex> lock(g_mutex);
+                    if (g_pending.erase(player->GetGUID()))
+                        g_activeCount.fetch_sub(1, std::memory_order_release);
+                }
+            }
+            return;
+        }
+
+        // --- live follow camera ----------------------------------------------
+        SpectatorState state;
+        if (!LookupState(player, state) || state.mode != Mode::Follow)
+            return;
+
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            auto it = g_spectators.find(player->GetGUID());
+            if (it == g_spectators.end())
+                return;
+            it->second.retargetAccumMs += diff;
+            if (it->second.retargetAccumMs < RETARGET_INTERVAL_MS)
+                return;
+            it->second.retargetAccumMs = 0;
+        }
+
+        Player* watched = ObjectAccessor::FindConnectedPlayer(state.watched);
+        if (IsWatchable(player, watched))
+            return;
+
+        // The seat went bad — the tank died, left the map, or logged out. Hand
+        // the camera to whoever is still driving rather than stranding the
+        // watcher on a corpse.
+        Player* next = ResolveWatchTarget(player);
+        if (!next || next->GetGUID() == state.watched)
+            return;
+
+        ClearViewpoint(player, state.watched);
+        player->SetViewpoint(next, true);
+        player->UpdateVisibilityForPlayer();
+
+        {
+            std::lock_guard<std::mutex> lock(g_mutex);
+            auto it = g_spectators.find(player->GetGUID());
+            if (it != g_spectators.end())
+                it->second.watched = next->GetGUID();
+        }
+
+        Announce(player, "Camera handed off to " + next->GetName() + ".");
+    }
+
     void BeginBotAiMoverWindow(Player* player)
     {
         if (!player || g_activeCount.load(std::memory_order_acquire) == 0)
             return;
 
-        ObjectGuid dummyGuid;
-        if (!LookupDummy(player, dummyGuid))
+        SpectatorState state;
+        if (!LookupState(player, state) || state.mode != Mode::Free)
             return;
 
         // Only swap when the mover really is our dummy — if some other charm
         // owns the mover, leave it alone.
         Unit* mover = player->m_mover;
-        if (mover && mover->GetGUID() == dummyGuid)
+        if (mover && mover->GetGUID() == state.dummy)
             player->m_mover = player;   // raw swap; no SetMover side effects
     }
 
@@ -212,14 +604,14 @@ namespace DcSpectator
         if (!player || g_activeCount.load(std::memory_order_acquire) == 0)
             return;
 
-        ObjectGuid dummyGuid;
-        if (!LookupDummy(player, dummyGuid))
+        SpectatorState state;
+        if (!LookupState(player, state) || state.mode != Mode::Free)
             return;     // Stop() ran mid-window and already restored control
 
         if (player->m_mover != player)
             return;     // window never opened (foreign charm) — nothing to undo
 
-        if (Creature* dummy = ObjectAccessor::GetCreature(*player, dummyGuid))
+        if (Creature* dummy = ObjectAccessor::GetCreature(*player, state.dummy))
             player->m_mover = dummy;
         // Dummy unresolvable while still registered: leave the mover on the
         // player; the teardown safety net will Stop() and clear the half-state.

--- a/src/Util/DcSpectator.h
+++ b/src/Util/DcSpectator.h
@@ -1,26 +1,47 @@
 /*
  * mod-dungeon-clear — DcSpectator.h
  *
- * Spectator free-camera mode (`.dc spectate` / addon "spectate"). Detaches the
- * human player into a free-flying camera while their character keeps running
- * under bot AI (bot-self mode). Mechanism: possess an invisible, unattackable,
- * flying WORLD_TRIGGER TempSummon via Unit::SetCharmedBy(CHARM_TYPE_POSSESS) —
- * the Eye of Acherus pattern. The client natively moves its camera and input
- * to the possessed unit, and the server streams visibility around the new
- * seer, so the camera can fly anywhere in the loaded map.
+ * Spectator camera (`.dc spectate` / addon "spectate"). Two modes, both of
+ * which detach the human's CAMERA from their body:
+ *
+ *   Free   — possess an invisible, unattackable, flying WORLD_TRIGGER
+ *            TempSummon via Unit::SetCharmedBy(CHARM_TYPE_POSSESS), the Eye of
+ *            Acherus pattern. The client natively moves its camera and input to
+ *            the possessed unit, so the camera flies anywhere in the map. The
+ *            player's own character keeps running under bot AI (bot-self mode).
+ *
+ *   Follow — ride a bot: Player::SetViewpoint(target, true), the same call
+ *            SPELL_AURA_BIND_SIGHT (Mind Vision) uses. The camera sits on the
+ *            watched unit and tracks it as the SERVER moves it, with the
+ *            client's normal orbit/zoom still live. The body is rooted for the
+ *            duration so blind movement keys can't walk it off.
+ *
+ * Why the modes use different mechanisms — the load-bearing lesson from the
+ * abandoned feat/cinematic-camera branch. A possessed unit is CLIENT-
+ * authoritative: the client owns its movement, so a server-driven "camera that
+ * follows the party" fights the client for control and loses. Farsight inverts
+ * that — the watched unit is an ordinary server-moved unit the client merely
+ * renders, so its motion is interpolated exactly as smoothly as any other mob's
+ * and we synthesise no motion of our own. Free-fly needs client control (you
+ * steer it); Follow must NOT have it. Do not "unify" them.
+ *
+ * The watched unit is re-resolved on a slow tick (Tick below), so the camera
+ * survives a leader-tank re-election, the tank dying, or the party moving on —
+ * it hands off to another live tank bot on the map instead of freezing on a
+ * corpse.
  *
  * This is session plumbing, not bot AI: it acts on the issuing player directly
  * and deliberately does NOT go through DungeonClearDispatch, the action/
- * trigger/strategy pipeline, or the leader-tank concept. It is independent of
- * the DC run — `dc off`/pause do not end spectate.
+ * trigger/strategy pipeline, or the leader-tank concept as a driver. It is
+ * independent of the DC run — `dc off`/pause do not end spectate.
  *
  * Threading: Start/Toggle run on the world thread (commands, the addon chat
- * hook), but the teardown hooks (death, teleport) fire on map threads, and the
- * AI mover window below runs on every map thread each player tick — so the
- * internal state map is mutex-guarded, with a lock-free active-count fast path
- * for the per-tick window. Per-player operations never race each other (a
- * player's session phase and map update are sequential); the lock only guards
- * the shared container across players on different maps.
+ * hook), but the teardown hooks (death, teleport) fire on map threads, and both
+ * the AI mover window and Tick run on every map thread each player tick — so
+ * the internal state map is mutex-guarded, with a lock-free active-count fast
+ * path for the per-tick entry points. Per-player operations never race each
+ * other (a player's session phase and map update are sequential); the lock only
+ * guards the shared container across players on different maps.
  */
 
 #ifndef _DUNGEON_CLEAR_DC_SPECTATOR_H
@@ -28,36 +49,102 @@
 
 #include <string>
 
+#include "ObjectGuid.h"
+
 class Player;
 
 namespace DcSpectator
 {
-    // True while `player` has an active spectator camera (guid-keyed lookup).
+    // True while `player` has an active spectator camera in EITHER mode
+    // (guid-keyed lookup).
     bool IsActive(Player* player);
+
+    // True while `player` is in Follow mode specifically.
+    bool IsFollowing(Player* player);
+
+    // The unit the Follow camera currently rides, or an empty guid when the
+    // player isn't following. For status readouts.
+    ObjectGuid WatchedGuid(Player* player);
+
+    // --- Free mode (possession) --------------------------------------------
 
     // Summon + possess the camera dummy. Returns false and fills `whyNot`
     // (when non-null) if the player is in a state that refuses possession.
     bool Start(Player* player, std::string* whyNot = nullptr);
 
-    // Tear down the possession and despawn the dummy. Idempotent — safe to
-    // call blind from every exit path (teleport, death, logout, toggle).
-    void Stop(Player* player);
-
-    // Stop if active, Start otherwise. Returns false only on a refused Start.
+    // Stop if active in any mode, else Start free-fly. Returns false only on a
+    // refused Start.
     bool Toggle(Player* player, std::string* whyNot = nullptr);
 
-    // Scoped "AI mover window". While spectating, the session's m_mover is the
-    // camera dummy, and the core packet handlers playerbots injects bot actions
-    // into (HandleUseItemOpcode, HandleGameObjectUseOpcode, …) silently drop on
-    // their remote-control guard `m_mover != _player` — so a self-bot could not
-    // use items (soulstone, healthstone, potions, food) while its human flew
-    // the camera. These two calls bracket the bot's AI tick (both fired from
-    // PLAYERHOOK_ON_AFTER_UPDATE on the player's map thread — see the mover
-    // window scripts in DungeonClearModule.cpp for the ordering contract) and
-    // swap m_mover back to the player for just that duration. Client movement
-    // packets for the dummy are processed in the session phases, never inside
-    // this window, so camera control is unaffected. Both are cheap no-ops
-    // while nobody on the server is spectating.
+    // --- Follow mode (farsight) --------------------------------------------
+
+    // Ride `target`'s camera. `target` may be null, in which case a watchable
+    // bot is resolved automatically (see ResolveWatchTarget). Switching from an
+    // active Free camera is handled internally — no need to Stop first.
+    bool StartFollow(Player* player, Player* target = nullptr,
+                     std::string* whyNot = nullptr);
+
+    // Stop if already following, StartFollow otherwise.
+    bool ToggleFollow(Player* player, Player* target = nullptr,
+                      std::string* whyNot = nullptr);
+
+    // The bot this player would watch: the leader tank of their group when they
+    // have one, else the elected dungeon-clear leader on their map, else any
+    // alive tank bot there. Null when the map holds nothing worth watching —
+    // which is the normal answer in the open world. `exclude` skips a candidate
+    // that is still live but on its way out (a logging-out bot is valid right
+    // up until it isn't, so handing the camera to it would be a bad seat).
+    Player* ResolveWatchTarget(Player* viewer, Player* exclude = nullptr);
+
+    // Arm a Follow camera that starts once `viewer` finishes zoning into
+    // `tank`'s instance. A teleport is asynchronous (the player spends a
+    // loading screen off-map, and the teleport teardown hook below deliberately
+    // stops any live camera on the way out), so the GM-watch entry point parks
+    // its intent here and Tick picks it up on arrival. Overwrites any pending
+    // request; Stop clears it. Pass gmModeApplied when the caller turned GM
+    // mode ON for this watch, so Stop can put the GM back as it found them.
+    void RequestFollowOnArrival(Player* viewer, ObjectGuid tankGuid,
+                                bool gmModeApplied = false);
+
+    // --- Lifecycle ----------------------------------------------------------
+
+    // Tear down whichever camera is active: the possession + dummy in Free
+    // mode, the viewpoint + root in Follow mode. Idempotent — safe to call
+    // blind from every exit path (teleport, death, logout, toggle).
+    void Stop(Player* player);
+
+    // MANDATORY crash guard, called for EVERY logging-out player (bots
+    // included), not just spectators. A Follow camera is an aura-less farsight,
+    // and nothing in the core resets a viewer's m_seer when the watched unit is
+    // destroyed: Player::SetViewpoint is only ever undone by the bind-sight
+    // AURA's own removal (SpellAuraEffects HandleBindSight), and ~Unit merely
+    // unlinks the shared-vision lists. So a watched bot logging out — which is
+    // exactly how a test run ends — would leave every viewer's m_seer dangling
+    // at freed memory, read by GetSightPosition() on the next visibility
+    // update. This is the same shape as the aura-less-possession death crash
+    // (see the spectator death guard in DungeonClearModule.cpp): the core's
+    // cleanup assumes an aura we don't have, so we do it ourselves, here, while
+    // the unit is still alive. Cheap no-op while nobody is spectating.
+    void NotifyWatchedLoggingOut(Player* watched);
+
+    // Slow per-player tick (PLAYERHOOK_ON_AFTER_UPDATE, the player's own map
+    // thread). Starts a pending arrival request, and re-resolves the watched
+    // unit for a live Follow camera. Cheap no-op while nobody is spectating.
+    void Tick(Player* player, uint32 diff);
+
+    // Scoped "AI mover window". While spectating in FREE mode, the session's
+    // m_mover is the camera dummy, and the core packet handlers playerbots
+    // injects bot actions into (HandleUseItemOpcode, HandleGameObjectUseOpcode,
+    // …) silently drop on their remote-control guard `m_mover != _player` — so
+    // a self-bot could not use items (soulstone, healthstone, potions, food)
+    // while its human flew the camera. These two calls bracket the bot's AI
+    // tick (both fired from PLAYERHOOK_ON_AFTER_UPDATE on the player's map
+    // thread — see the mover window scripts in DungeonClearModule.cpp for the
+    // ordering contract) and swap m_mover back to the player for just that
+    // duration. Client movement packets for the dummy are processed in the
+    // session phases, never inside this window, so camera control is
+    // unaffected. Follow mode never redirects the mover, so both are no-ops
+    // there. Both are cheap no-ops while nobody on the server is spectating.
     void BeginBotAiMoverWindow(Player* player);
     void EndBotAiMoverWindow(Player* player);
 }


### PR DESCRIPTION
## Why you couldn't spectate a test run

`DcSpectator::Start` has **never** had a group requirement — it checks
SpectateEnable, in-a-dungeon, alive, no vehicle/taxi/charm, and nothing else.

The group gate lived entirely in the addon's **transport**: `SendDcCommand` only
sends on PARTY/RAID, so a GM with no group short-circuited to *"You must be in a
party to send bot commands"* and the server never saw the click. The test harness
deliberately keeps the GM out of the bot party, so the one person who most wants
to spectate is the one person the button refuses.

## What's here

**Solo transport** — whisper-to-self addon message when there's no party;
`IsDcAddonCommand` accepts `CHAT_MSG_WHISPER`. No new authority: bot commands
still self-authorize server-side.

**Follow cam** — `.dc spectate follow [name]`, or right-click Spectate.
`Player::SetViewpoint` (the call `SPELL_AURA_BIND_SIGHT` uses) rides a bot, so
the client interpolates ordinary server movement and we synthesise none of our
own. The body is rooted; a slow tick hands the camera off on death / logout /
leader re-election.

**GM watch** — `.dc test watch [selector]` / `off`. Resolves the run, enables GM
mode so the watcher can't aggro and invalidate the run it's observing, binds +
teleports into the instance, and arms the camera to start on arrival.

## Why Follow is a different mechanism from free-fly

A possessed unit is **client-authoritative** — the client owns its movement, so a
server-driven "camera that follows the party" fights the client and loses. That's
what killed `feat/cinematic-camera`: its v1 already had the load-bearing packet,
and every commit after is jank-chasing → tripod shots → client-side chase → GUID
forgery to fake a party unit → revert. Farsight inverts it. Do not unify them.

## Crash guard (please review this bit)

Same shape as the aura-less-possession death crash: nothing in the core resets a
viewer's `m_seer` when the watched unit is destroyed — `SetViewpoint` is only
ever undone by the bind-sight *aura's* removal, and `~Unit` merely unlinks the
shared-vision lists. A watched bot logging out (exactly how a test run **ends**)
would leave `m_seer` dangling at freed memory for `GetSightPosition()` to read.
`NotifyWatchedLoggingOut` runs off the before-logout hook for every player, bots
included, and clears or hands off every viewer while the unit is still alive.

## Testing

`clang -fsyntax-only` clean on all five changed TUs. The gtest target compiles
only `t/*.cpp`, so it covers none of this — there's no new pure kernel. **Not yet
validated in-game.**

Needs the companion addon commit (`mod-dungeon-clear-addon` v3.4, committed
locally, not pushed) for the button behaviour; the slash commands work without it.

Phase 2 (the gimbal — cinematic framing via a camera bot in the GM's own group,
which is what makes v5's roster forgery unnecessary) is written up in
`deployment-files/docs/mod-dungeon-clear_spectator-gimbal_plan.md` and
deliberately not started.