### PR TITLE
fix(diagnostics): derive snapshot verdict from PvE refs

### DIFF
--- a/src/TestRun/DcDiagSnapshot.cpp
+++ b/src/TestRun/DcDiagSnapshot.cpp
@@ -118,7 +118,7 @@ namespace
             bool const canAttackMe =
                 !asCreature || !asCreature->AI() || asCreature->AI()->CanAIAttack(member);
             bool const legitimate = reachable && canAttackMe;
-            if (IsLegitimatePvECombatHolder(pvp, legitimate))
+            if (DcDiag::IsLegitimatePvECombatHolder(pvp, legitimate))
                 anyLegitimatePvEHolder = true;
 
             if (m.combatHolders.size() >= kMaxHoldersPerMember)
@@ -165,7 +165,7 @@ namespace
 
         // No refs at all is the hatch's "opaque/forced combat, leave it alone"
         // branch — legitimate by default, so it must NOT read as phantom here.
-        bool const hasLegitimateHolder = HasLegitimatePvECombatHolder(
+        bool const hasLegitimateHolder = DcDiag::HasLegitimatePvECombatHolder(
             !cm.GetPvECombatRefs().empty(), anyLegitimatePvEHolder);
         // The verdict itself goes through the SAME kernel the trigger uses, so
         // the snapshot cannot drift from the hatch on the one field a reader

--- a/src/TestRun/DcDiagSnapshot.cpp
+++ b/src/TestRun/DcDiagSnapshot.cpp
@@ -92,7 +92,7 @@ namespace
         Map* const map = member->GetMap();
         m.attackerCount = static_cast<std::uint32_t>(member->getAttackers().size());
 
-        bool anyLegitimate = false;
+        bool anyLegitimatePvEHolder = false;
         auto describe = [&](Unit* other, bool suppressed, bool pvp)
         {
             if (!other)
@@ -118,8 +118,8 @@ namespace
             bool const canAttackMe =
                 !asCreature || !asCreature->AI() || asCreature->AI()->CanAIAttack(member);
             bool const legitimate = reachable && canAttackMe;
-            if (legitimate)
-                anyLegitimate = true;
+            if (IsLegitimatePvECombatHolder(pvp, legitimate))
+                anyLegitimatePvEHolder = true;
 
             if (m.combatHolders.size() >= kMaxHoldersPerMember)
                 return;
@@ -165,7 +165,8 @@ namespace
 
         // No refs at all is the hatch's "opaque/forced combat, leave it alone"
         // branch — legitimate by default, so it must NOT read as phantom here.
-        bool const hasLegitimateHolder = anyLegitimate || !m.holderRefCount;
+        bool const hasLegitimateHolder = HasLegitimatePvECombatHolder(
+            !cm.GetPvECombatRefs().empty(), anyLegitimatePvEHolder);
         // The verdict itself goes through the SAME kernel the trigger uses, so
         // the snapshot cannot drift from the hatch on the one field a reader
         // will trust it on. Only the per-holder legitimacy above is mirrored by
@@ -202,6 +203,16 @@ namespace
 
 namespace DcDiag
 {
+    bool IsLegitimatePvECombatHolder(bool isPvp, bool holderIsLegitimate)
+    {
+        return !isPvp && holderIsLegitimate;
+    }
+
+    bool HasLegitimatePvECombatHolder(bool hasPvERefs, bool anyLegitimatePvEHolder)
+    {
+        return !hasPvERefs || anyLegitimatePvEHolder;
+    }
+
     Snapshot Capture(Player* tank, char const* capturedAt)
     {
         Snapshot snap;

--- a/src/TestRun/DcDiagSnapshot.h
+++ b/src/TestRun/DcDiagSnapshot.h
@@ -217,6 +217,14 @@ namespace DcDiag
     // tank (returns valid == false) and on a solo bot with no group.
     Snapshot Capture(Player* tank, char const* capturedAt);
 
+    // Match the recovery trigger's PvE-only holder verdict while retaining PvP
+    // refs for diagnostic display.
+    bool IsLegitimatePvECombatHolder(bool isPvp, bool holderIsLegitimate);
+
+    // An empty PvE ref map is the trigger's opaque-combat branch. A non-empty
+    // PvE ref map is legitimate only when at least one PvE holder is legitimate.
+    bool HasLegitimatePvECombatHolder(bool hasPvERefs, bool anyLegitimatePvEHolder);
+
     // Serialize as a JSON object (no trailing comma, no key) onto the stream,
     // matching DcTestRunRecord's hand-rolled JSONL style.
     void AppendJson(std::ostringstream& s, Snapshot const& snap);

--- a/t/TestDcDiagSnapshot.cpp
+++ b/t/TestDcDiagSnapshot.cpp
@@ -381,3 +381,15 @@ TEST(DcDiagSnapshotTest, SummarizeFlagsPhantomAndOffEngineMembers)
     EXPECT_NE(line.find("PHANTOM-COMBAT=1"), std::string::npos);
     EXPECT_NE(line.find("FLAGGED-OFF-COMBAT-ENGINE=1"), std::string::npos);
 }
+
+TEST(DcDiagSnapshotTest, PhantomVerdictUsesPveRefsOnly)
+{
+    EXPECT_FALSE(DcDiag::IsLegitimatePvECombatHolder(true, true));
+    EXPECT_TRUE(DcDiag::IsLegitimatePvECombatHolder(false, true));
+
+    // A legitimate PvP ref must not rescue phantom PvE refs. With no PvE refs,
+    // the trigger preserves its opaque-combat exception.
+    EXPECT_FALSE(DcDiag::HasLegitimatePvECombatHolder(true, false));
+    EXPECT_TRUE(DcDiag::HasLegitimatePvECombatHolder(false, false));
+    EXPECT_TRUE(DcDiag::HasLegitimatePvECombatHolder(true, true));
+}


### PR DESCRIPTION
## Summary

Addresses #15 by making the snapshot phantom combat verdict derive from PvE combat references only. PvP references remain serialized for diagnostic display.

## Root cause

`DcDiagSnapshot::CaptureCombatHolders` walks both PvE and PvP reference maps, and the previous verdict flag could be satisfied by either kind of holder. The recovery trigger in `DungeonClearTriggers.cpp` evaluates only `GetPvECombatRefs()`, so a legitimate PvP holder could make the snapshot disagree with the recovery behavior when phantom PvE references were also present.

## Change

1. Track legitimate holders from PvE references only.
2. Preserve the empty PvE reference map as the opaque combat exception.
3. Continue serializing PvP references for display.
4. Add `PhantomVerdictUsesPveRefsOnly` regression coverage.
5. Qualify the two `DcDiag` helper calls so `DcDiagSnapshot.cpp` compiles from its anonymous namespace.

## Validation

The existing `unit_tests` build compiled `modules/mod-dungeon-clear/src/TestRun/DcDiagSnapshot.cpp.o` successfully after the namespace fix. The broader build reached 71% while compiling unrelated Playerbot objects and was then interrupted before linking, so no full-suite result is claimed.

Additional checks passed: `git diff --check`, `bash -n tools/check_determinism.sh`, `python3 tools/check_config_reads.py`, and `python3 tools/check_msvc_portability.py`.
